### PR TITLE
Add Unity desktop and normalize variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ function getIconThemeCMD () {
    */
   let desktop = process.env.XDG_CURRENT_DESKTOP
   let key, path
-  switch (desktop) {
+  switch (desktop.toUpperCase()) {
+    case 'UNITY':
     case 'GNOME':
       key = 'icon-theme'
       path = 'org.gnome.desktop.interface'


### PR DESCRIPTION
This commit adds Unity as a possible Desktop when
getting the Icon Theme. Unity's settings are the
same as Gnome but in certain cases the current
desktop will distinguish between one or the other
one.

Additionally, the variable that controls which
desktop to look for themes for is normalized so
unity, Unity, UNITY are all considered the same
environment.